### PR TITLE
Fix auto-complete on GelboLube

### DIFF
--- a/filterlist/imageboard/GelboLube.txt
+++ b/filterlist/imageboard/GelboLube.txt
@@ -118,6 +118,8 @@ gelbooru.com##.alert-info:has(a[href*="twitter.com/gelbooru"])
 @@||gelbooru.com/script/application.js|$script,first-party
 @@||gelbooru.com/script/miscJs.js?$script,first-party
 @@||gelbooru.com/script/miscJs.js|$script,first-party
+@@||gelbooru.com/script/autocomplete.*.js?$script,first-party
+@@||gelbooru.com/script/autocomplete.*.js|$script,first-party
 
 ! 3. Actual WebM Videos (Legitimate WebM vids are loaded from /images/ only, otherwise is adverts!)
 @@||gelbooru.com/images/$media


### PR DESCRIPTION
Fixes auto-complete due to recent change.

This allows for auto-complete script to load, and it appears that previously, auto-complete was used by misc script. I have not touched the misc script loading. If it's not needed anymore - you can remove it at your discretion.